### PR TITLE
Paths Interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,28 @@ project(sst-plugininfra VERSION 0.5 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME} INTERFACE include)
 
 add_subdirectory(libs/filesystem)
 add_subdirectory(libs/tinyxml)
 add_library(${PROJECT_NAME}::tinyxml ALIAS tinyxml)
+
+
+configure_file(src/paths_subst.cpp.in ${CMAKE_BINARY_DIR}/gen/paths_subst.cpp)
+
+add_library(${PROJECT_NAME} EXCLUDE_FROM_ALL ${CMAKE_BINARY_DIR}/gen/paths_subst.cpp)
+target_include_directories(${PROJECT_NAME} PUBLIC include)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${PROJECT_NAME}::filesystem)
+
+
+if (WIN32)
+    target_sources(${PROJECT_NAME} PRIVATE src/paths_windows.cpp)
+elseif (APPLE)
+    target_sources(${PROJECT_NAME} PRIVATE src/paths_macos.mm)
+    target_link_libraries(${PROJECT_NAME} PRIVATE "-framework Foundation")
+else ()
+    target_sources(${PROJECT_NAME} PRIVATE src/paths_linux.cpp)
+    target_link_libraries(${PROJECT_NAME} PUBLIC dl)
+endif ()
 
 
 get_directory_property(parent_dir PARENT_DIRECTORY)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,4 +39,5 @@ jobs:
           pushd ./build/test-binary 
           ./sst-plugininfra-tests
           ./sst-tixml-tests
+          ./dumppaths
         displayName: Run tests with cmake

--- a/include/sst/plugininfra.h
+++ b/include/sst/plugininfra.h
@@ -1,13 +1,2 @@
 
-#ifndef _SST_CPP_FILTERS_H
-#define _SST_CPP_FILTERS_H
-
-namespace sst
-{
-namespace plugininfra
-{
-inline int addOne(int x) { return x + 1; }
-} // namespace filters
-} // namespace sst
-
-#endif
+#include "plugininfra/paths.h"

--- a/include/sst/plugininfra/paths.h
+++ b/include/sst/plugininfra/paths.h
@@ -1,0 +1,58 @@
+//
+// Created by paul on 1/24/22.
+//
+
+#ifndef SST_PLUGININFRA_PATHS_H
+#define SST_PLUGININFRA_PATHS_H
+
+#include "filesystem/import.h"
+#include <string>
+
+
+namespace sst
+{
+namespace plugininfra
+{
+namespace paths
+{
+
+/*
+ * The CMAKE_INSTALL_PREFIX
+ */
+extern std::string CMAKE_INSTALL_PREFIX;
+
+/*
+ * HomePath is the path user thinks of as their root. On unixes this is the "~" directory
+ * and on windows it is c:\users\blah
+ */
+fs::path homePath();
+
+/*
+ * sharedLibraryBinaryPath is the path to the running loaded dll which has linked this
+ * and can be used to find the dll location for portable installs and the like
+ */
+fs::path sharedLibraryBinaryPath();
+
+/*
+ * bestDocumentsFolderPathFor gives the "~/Documents/productName" folder or OS specific equivalent.
+ * Importantly this does *not* return any sort of portable name but only uses the OS-specific
+ * documents folder resolution strategy. For portable documents folder use sharedLibraryBinaryPath
+ */
+fs::path bestDocumentsFolderPathFor(const std::string &productName);
+
+/*
+ * bestLibrarySharedFolderPathFor returns the "/Library/Application Support/programName"
+ * or "%PROGRAM_DATA%/programName" or "/usr/share/programName" type folder, adjusted for
+ * the CMAKE install prefix and XDG settings (on linux), and using the OS built in APIs
+ * on Mac and Windows. "userLevel" on mac and linux returns the user-specific library
+ * folder (so "~/Library/Application Support" on mac and "~/.local/share or XDG based on
+ * linux).
+ */
+fs::path bestLibrarySharedFolderPathFor(const std::string &productName, bool userLevel = false);
+
+
+}
+}
+}
+
+#endif // SST_PLUGININFRA_PATHS_H

--- a/src/paths_linux.cpp
+++ b/src/paths_linux.cpp
@@ -1,0 +1,96 @@
+/*
+ * paths_linux
+ *
+ * Semantics are:
+ */
+
+#include "filesystem/import.h"
+#include "sst/plugininfra/paths.h"
+#include <stdexcept>
+#include <stdlib.h>
+#include <dlfcn.h>
+
+namespace sst
+{
+namespace plugininfra
+{
+namespace paths
+{
+fs::path homePath()
+{
+    const char *const path = std::getenv("HOME");
+    if (!path || !path[0])
+        throw std::runtime_error{"The environment variable HOME is unset or empty"};
+    return fs::path{path};
+}
+
+fs::path sharedLibraryBinaryPath()
+{
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<const void *>(&sharedLibraryBinaryPath), &info) || !info.dli_fname[0])
+    {
+        // If dladdr(3) returns zero, dlerror(3) won't know why either
+        throw std::runtime_error{"Failed to retrieve shared object file name"};
+    }
+    return fs::path{info.dli_fname};
+}
+
+/*
+ * The waterfall we use here is as follows
+ *
+ * 1. Is XDG_DOCUMENTS_DIR set - if so use that with productName
+ * 2. Does ~/Documents exists? If so use that
+ * 3. Else use ~/.productName
+ */
+fs::path bestDocumentsFolderPathFor(const std::string &productName)
+{
+    if (auto xdgdd = getenv("XDG_DOCUMENTS_DIR"))
+    {
+        auto xdgpath = fs::path{xdgdd} / productName;
+        return xdgpath;
+    }
+
+    auto hp = homePath();
+
+    // If the user has already made one pick it
+    auto documentpn = hp / "Documents" / productName;
+    auto dotpn = hp / ("." + productName);
+
+    if (fs::is_directory(dotpn))
+        return dotpn;
+    if (fs::is_directory(documentpn))
+        return documentpn;
+
+    // Neither is there. Do I have a Documents folder?
+    if (auto documents = hp / "Documents"; fs::is_directory(documents))
+        return documents / productName;
+    return dotpn;
+}
+
+fs::path bestLibrarySharedFolderPathFor(const std::string &productName, bool userLevel)
+{
+    if (userLevel)
+    {
+        fs::path home = homePath();
+
+        if (const char *xdgDataPath = getenv("XDG_DATA_HOME"))
+        {
+            return fs::path{xdgDataPath} / productName;
+        }
+        else
+        {
+            return home  / ".local" / "share" / productName;
+        }
+    }
+
+    if (auto cmi = fs::path{CMAKE_INSTALL_PREFIX} / "share" / productName; fs::is_directory(cmi))
+        return cmi;
+
+    if (auto cmi = fs::path{"/usr"} / "share" / productName; fs::is_directory(cmi))
+        return cmi;
+
+    return fs::path{CMAKE_INSTALL_PREFIX} / "share" / productName;
+}
+}
+}
+}

--- a/src/paths_macos.mm
+++ b/src/paths_macos.mm
@@ -1,0 +1,65 @@
+/*
+ * paths_linux
+ *
+ * Semantics are:
+ */
+
+#include "filesystem/import.h"
+#include "sst/plugininfra/paths.h"
+#include <dlfcn.h>
+#include <Foundation/Foundation.h>
+
+namespace sst
+{
+namespace plugininfra
+{
+namespace paths
+{
+fs::path homePath()
+{
+    const char *const path = std::getenv("HOME");
+    if (!path || !path[0])
+        throw std::runtime_error{"The environment variable HOME is unset or empty"};
+    return fs::path{path};
+}
+
+fs::path sharedLibraryBinaryPath()
+{
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<const void *>(&sharedLibraryBinaryPath), &info) ||
+        !info.dli_fname[0])
+    {
+        // If dladdr(3) returns zero, dlerror(3) won't know why either
+        throw std::runtime_error{"Failed to retrieve shared object file name"};
+    }
+    return fs::path{info.dli_fname};
+}
+
+fs::path bestDocumentsFolderPathFor(const std::string &productName)
+{
+    auto *fileManager = [NSFileManager defaultManager];
+    auto *resultURLs = [fileManager URLsForDirectory:NSDocumentDirectory
+                                           inDomains:NSUserDomainMask];
+    if (resultURLs)
+    {
+        auto *u = [resultURLs objectAtIndex:0];
+        return fs::path{[u fileSystemRepresentation]} / productName;
+    }
+    return fs::path{};
+}
+
+fs::path bestLibrarySharedFolderPathFor(const std::string &productName, bool userLevel)
+{
+    auto *fileManager = [NSFileManager defaultManager];
+    auto key = userLevel ? NSUserDomainMask : NSLocalDomainMask;
+    auto *resultURLs = [fileManager URLsForDirectory:NSApplicationSupportDirectory inDomains:key];
+    if (resultURLs)
+    {
+        auto *u = [resultURLs objectAtIndex:0];
+        return fs::path{[u fileSystemRepresentation]} / productName;
+    }
+    return fs::path{};
+}
+} // namespace paths
+} // namespace plugininfra
+} // namespace sst

--- a/src/paths_subst.cpp.in
+++ b/src/paths_subst.cpp.in
@@ -1,0 +1,13 @@
+#include "sst/plugininfra/paths.h"
+#include <string>
+
+namespace sst
+{
+namespace plugininfra
+{
+namespace paths
+{
+std::string CMAKE_INSTALL_PREFIX = "@CMAKE_INSTALL_PREFIX@";
+}
+}
+}

--- a/src/paths_windows.cpp
+++ b/src/paths_windows.cpp
@@ -1,0 +1,78 @@
+/*
+ * paths_linux
+ *
+ * Semantics are:
+ */
+
+#include "filesystem/import.h"
+#include "sst/plugininfra/paths.h"
+#include <system_error>
+#include <windows.h>
+#include <shlobj.h>
+
+namespace sst
+{
+namespace plugininfra
+{
+namespace paths
+{
+
+fs::path knownFolderPath(REFKNOWNFOLDERID rfid)
+{
+    fs::path path;
+    PWSTR pathStr{};
+    if (::SHGetKnownFolderPath(rfid, 0, nullptr, &pathStr) == S_OK)
+        path = pathStr;
+    ::CoTaskMemFree(pathStr);
+    if (path.empty())
+        throw std::runtime_error{"Failed to retrieve known folder path"};
+    return path;
+}
+
+
+fs::path homePath()
+{
+    return knownFolderPath(FOLDERID_Profile);
+}
+
+fs::path sharedLibraryBinaryPath()
+{
+    HMODULE hmodule;
+    if (!::GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                  GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                              reinterpret_cast<LPCWSTR>(&sharedLibraryBinaryPath), &hmodule))
+    {
+        throw std::system_error{int(::GetLastError()), std::system_category(),
+                                "Failed to retrieve module handle"};
+    }
+
+    for (std::vector<WCHAR> buf{MAX_PATH};; buf.resize(buf.size() * 2))
+    {
+        const auto len = ::GetModuleFileNameW(hmodule, &buf[0], buf.size());
+        if (!len)
+            throw std::system_error{int(::GetLastError()), std::system_category(),
+                                    "Failed to retrieve module file name"};
+        if (len < buf.size())
+            return fs::path{&buf[0]};
+    }
+}
+
+fs::path bestDocumentsFolderPathFor(const std::string &productName)
+{
+    return knownFolderPath(FOLDERID_Documents) / productName;
+}
+
+fs::path bestLibrarySharedFolderPathFor(const std::string &productName, bool isUser)
+{
+    if (!isUser)
+    {
+        return knownFolderPath(FOLDERID_ProgramData) / productName;
+    }
+    else
+    {
+        return knownFolderPath(FOLDERID_LocalAppData) / productName;
+    }
+}
+}
+}
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(sst-plugininfra-tests)
 target_include_directories(sst-plugininfra-tests PRIVATE tests)
-target_link_libraries(sst-plugininfra-tests PRIVATE ${PROJECT_NAME} ${PROJECT_NAME}::filesystem)
+target_link_libraries(sst-plugininfra-tests PUBLIC sst-plugininfra sst-plugininfra::filesystem)
 target_sources(sst-plugininfra-tests PRIVATE
         tests.cpp)
 
@@ -8,7 +8,12 @@ add_executable(sst-tixml-tests)
 target_sources(sst-tixml-tests PRIVATE ${CMAKE_SOURCE_DIR}/libs/tinyxml/test/xmltest.cpp)
 target_link_libraries(sst-tixml-tests PRIVATE tinyxml)
 
+add_executable(dumppaths)
+target_sources(dumppaths PRIVATE dumppaths.cpp)
+target_link_libraries(dumppaths sst-plugininfra)
+
 add_custom_target(sst-all-tests ALL)
+add_dependencies(sst-all-tests dumppaths)
 add_dependencies(sst-all-tests sst-tixml-tests)
 add_dependencies(sst-all-tests sst-plugininfra-tests)
 
@@ -19,6 +24,7 @@ add_custom_command(TARGET sst-all-tests
         COMMAND ${CMAKE_COMMAND} -E make_directory test-binary
         COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:sst-plugininfra-tests>" test-binary
         COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:sst-tixml-tests>" test-binary
+        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:dumppaths>" test-binary
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/libs/tinyxml/test/utf8test.xml test-binary
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/libs/tinyxml/test/utf8testverify.xml test-binary
         )

--- a/tests/dumppaths.cpp
+++ b/tests/dumppaths.cpp
@@ -1,0 +1,13 @@
+#include "sst/plugininfra/paths.h"
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+    using namespace sst::plugininfra::paths;
+    std::cout << "Path Display for Platform\n";
+    std::cout << "home    : " << homePath().u8string() << "\n";
+    std::cout << "bin     : " << sharedLibraryBinaryPath().u8string() << "\n";
+    std::cout << "docs    : " << bestDocumentsFolderPathFor( "test-sst-plugininfra").u8string() << "\n";
+    std::cout << "lib     : " << bestLibrarySharedFolderPathFor( "test-sst-plugininfra" ).u8string() << "\n";
+    std::cout << "lib usr : " << bestLibrarySharedFolderPathFor( "test-sst-plugininfra", true ).u8string() << "\n";
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -4,11 +4,6 @@
 #include <sst/plugininfra.h>
 #include "filesystem/import.h"
 
-TEST_CASE("Basic")
-{
-    SECTION("Base Test") { REQUIRE(sst::plugininfra::addOne(1) == 2); }
-}
-
 TEST_CASE("FileSystem")
 {
     SECTION("Can make a path")
@@ -17,6 +12,16 @@ TEST_CASE("FileSystem")
         auto s = p.u8string();
         s[3] = ' ';
         REQUIRE(s == "tmp var");
+    }
+}
+
+TEST_CASE( "Documents Folder" )
+{
+    SECTION( "Got a documents folder" )
+    {
+        auto dpath = sst::plugininfra::paths::bestDocumentsFolderPathFor("surge-test");
+        std::cout << dpath.u8string() << std::endl;
+        REQUIRE(true);
     }
 }
 


### PR DESCRIPTION
This commit introduces a set of fs::path returning cross
platform functions to resolve common document, home
and application support paths using the various semantics
the OS supports (win/mac) or we've gleaned from the wild + XDG
(lin).