### PR TITLE
Fix an infinite loop on error in keybindings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         mac:
-          imageName: 'macos-10.15'
+          imageName: 'macos-latest'
           isMac: True
         win:
           imageName: 'windows-2019'

--- a/include/sst/plugininfra/keybindings.h
+++ b/include/sst/plugininfra/keybindings.h
@@ -77,10 +77,14 @@ template <typename FUNCS, int maxFunc, typename KEY /* = juce::KeyPress */> stru
         Binding(int kc) : type(KEYCODE), keyCode(kc), modifier(NONE) {}
         Binding() {}
 
-        bool operator==(const Binding &other) const {
-            if (modifier != other.modifier) return false;
-            if (active != other.active) return false;
-            if (type != other.type) return false;
+        bool operator==(const Binding &other) const
+        {
+            if (modifier != other.modifier)
+                return false;
+            if (active != other.active)
+                return false;
+            if (type != other.type)
+                return false;
             if (type == KEYCODE)
             {
                 if (keyCode != other.keyCode)
@@ -202,7 +206,9 @@ template <typename FUNCS, int maxFunc, typename KEY /* = juce::KeyPress */> stru
             }
             else
             {
-                std::cerr << "Ignoring binding for unknown element " << c->Attribute("function") << std::endl;
+                std::cerr << "Ignoring binding for unknown element " << c->Attribute("function")
+                          << std::endl;
+                c = c->NextSiblingElement();
                 continue;
             }
 


### PR DESCRIPTION
If the keybindings found an unknown keybinding in the XML they
would loop forever in a hang. This is aprticularly painful when
downgrading from 1.n to 1.m m < n and n has bindings m does not,
in which it looks like a hang until you blow away your binding XML