### PR TITLE
Fix a missing header for gcc12/win

### DIFF
--- a/src/paths_windows.cpp
+++ b/src/paths_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * paths_linux
+ * paths_windows
  *
  * Semantics are:
  */
@@ -9,6 +9,7 @@
 #include <system_error>
 #include <windows.h>
 #include <shlobj.h>
+#include <vector>
 
 namespace sst
 {


### PR DESCRIPTION
gcc12/windows was missing an include vector.
Addresses https://github.com/surge-synthesizer/surge-rack/issues/540