### PR TITLE
Make ghc filesystem and tinyxml optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,20 @@ project(sst-plugininfra VERSION 0.5 LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 
 
-add_subdirectory(libs/filesystem)
-add_subdirectory(libs/tinyxml)
-add_library(${PROJECT_NAME}::tinyxml ALIAS tinyxml)
-add_subdirectory(libs/strnatcmp)
-add_library(${PROJECT_NAME}::strnatcmp ALIAS strnatcmp)
+option(SST_PLUGININFRA_FILESYSTEM_FORCE_PLATFORM "Use std::filesystem from the platform headers no matter what" OFF)
+option(SST_PLUGININFRA_PROVIDE_TINYXML "Provide tinyxml as a target" ON)
+option(SST_PLUGININFRA_PROVIDE_STRNATCMP "Provide strnatcmp as a target" ON)
 
+add_subdirectory(libs/filesystem)
+if (${SST_PLUGININFRA_PROVIDE_TINYXML})
+    add_subdirectory(libs/tinyxml)
+    add_library(${PROJECT_NAME}::tinyxml ALIAS tinyxml)
+endif ()
+
+if (${SST_PLUGININFRA_PROVIDE_STRNATCMP})
+    add_subdirectory(libs/strnatcmp)
+    add_library(${PROJECT_NAME}::strnatcmp ALIAS strnatcmp)
+endif ()
 
 configure_file(src/paths_subst.cpp.in ${CMAKE_BINARY_DIR}/gen/paths_subst.cpp)
 

--- a/libs/filesystem/CMakeLists.txt
+++ b/libs/filesystem/CMakeLists.txt
@@ -43,9 +43,15 @@ if (UNIX AND NOT APPLE)
 else ()
     set(SST_PLUGININFRA_FILESYSTEM_FORCE_GHC OFF CACHE BOOL "Force GHC filesystem implementation")
 endif ()
-if (${SST_PLUGININFRA_FILESYSTEM_FORCE_GHC})
+
+if (${SST_PLUGININFRA_FILESYSTEM_FORCE_PLATFORM})
+    message(STATUS "Forcing filesystem to platform")
+    use_platform_fs()
+elseif (${SST_PLUGININFRA_FILESYSTEM_FORCE_GHC})
+    message(STATUS "Forcing filesystem to GHC")
     use_ghc_fs()
 else ()
+    message(STATUS "Detecting Filesystem Support")
     include(CheckCXXSourceCompiles)
     check_cxx_source_compiles("
     #include <filesystem>

--- a/scripts/installer_mac/make_installer.sh
+++ b/scripts/installer_mac/make_installer.sh
@@ -139,7 +139,7 @@ cat > $TMPDIR/distribution.xml << XMLEND
     ${AU_PKG_REF}
     ${CLAP_PKG_REF}
     ${APP_PKG_REF}
-    <options require-scripts="false" customize="always" />
+    <options require-scripts="false" customize="always" hostArchitectures="x86_64,arm64" />
     <choices-outline>
         ${VST3_CHOICE}
         ${AU_CHOICE}


### PR DESCRIPTION
Add cmake options so basically it is easier to force choices externally.