### PR TITLE
cpufeatures on arm requires cstdint

### DIFF
--- a/include/sst/plugininfra/cpufeatures.h
+++ b/include/sst/plugininfra/cpufeatures.h
@@ -3,6 +3,7 @@
 #define SST_PLUGININFRA_CPUFEATURES_H
 
 #include <string>
+#include <cstdint>
 
 namespace sst
 {


### PR DESCRIPTION
since it uses uint64_t
removes an OBS patch